### PR TITLE
fix error: --dry-run flag without a value was specified.

### DIFF
--- a/deployment/webhook-create-signed-cert.sh
+++ b/deployment/webhook-create-signed-cert.sh
@@ -126,5 +126,5 @@ echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
 kubectl create secret generic ${secret} \
         --from-file=key.pem=${tmpdir}/server-key.pem \
         --from-file=cert.pem=${tmpdir}/server-cert.pem \
-        --dry-run -o yaml |
+        --dry-run=client -o yaml |
     kubectl -n ${namespace} apply -f -

--- a/env-injector-webhook/templates/pre-install-configmap.yaml
+++ b/env-injector-webhook/templates/pre-install-configmap.yaml
@@ -148,7 +148,7 @@ data:
     kubectl create secret generic ${secret} \
             --from-file=key.pem=${tmpdir}/server-key.pem \
             --from-file=cert.pem=${tmpdir}/server-cert.pem \
-            --dry-run -o yaml |
+            --dry-run=client -o yaml |
         kubectl -n ${namespace} apply -f -
 
 


### PR DESCRIPTION
Fix
error: --dry-run flag without a value was specified. A value must be set: "none", "server", or "client"
error: no objects passed to apply

Possibly not working with newer versions of kubectl.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
