### PR TITLE
DTSPO-8139 Update env injector api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Node affinity is currently limited to RequiredDuringSchedulingIgnoredDuringExecu
 
 ## Prerequisites
 
-Kubernetes 1.9.0 or above with the `admissionregistration.k8s.io/v1beta1` API enabled. Verify that by the following command:
+Kubernetes 1.22.0 or above with the `admissionregistration.k8s.io/v1` API enabled. Verify that by the following command:
 ```
-kubectl api-versions | grep admissionregistration.k8s.io/v1beta1
+kubectl api-versions | grep admissionregistration.k8s.io/v1
 ```
 The result should be:
 ```
-admissionregistration.k8s.io/v1beta1
+admissionregistration.k8s.io/v1
 ```
 
 In addition, the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers should be added and listed in the correct order in the admission-control flag of kube-apiserver.

--- a/deployment/mutatingwebhook-ca-bundle.yaml
+++ b/deployment/mutatingwebhook-ca-bundle.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: env-injector-webhook-cfg

--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: env-injector-webhook-cfg

--- a/env-injector-webhook/Chart.yaml
+++ b/env-injector-webhook/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: A Helm chart for kubernetes environment injector mutating webhook
 name: env-injector-webhook
 home: https://github.com/hmcts/k8s-env-injector
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: HMCTS Platform engineering team

--- a/env-injector-webhook/templates/mutatingwebhook.yaml
+++ b/env-injector-webhook/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "chart-env-injector.name" . }}-cfg

--- a/webhook.go
+++ b/webhook.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,7 +61,7 @@ type patchOperation struct {
 
 func init() {
 	_ = corev1.AddToScheme(runtimeScheme)
-	_ = admissionregistrationv1beta1.AddToScheme(runtimeScheme)
+	_ = admissionregistrationv1.AddToScheme(runtimeScheme)
 }
 
 func loadConfig(configFile string) (*Config, error) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-8139


### Change description ###
Issue for v1.22 
`no matches for kind "MutatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1"`
Due to - "The admissionregistration.k8s.io/v1beta1 API version of MutatingWebhookConfiguration and ValidatingWebhookConfiguration is no longer served as of v1.22." This updates the API version to v1 for MutatingWebhookConfiguration.

Will test in SBOX after this is created as a release in PR: https://github.com/hmcts/cnp-flux-config/pull/16252/files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
