### PR TITLE
Add new required fields

### DIFF
--- a/deployment/mutatingwebhook-ca-bundle.yaml
+++ b/deployment/mutatingwebhook-ca-bundle.yaml
@@ -6,6 +6,8 @@ metadata:
     app: env-injector
 webhooks:
   - name: env-injector.hmcts.net
+    admissionReviewVersions: [“v1”, “v1beta1"]
+    sideEffects: NoneOnDryRun
     clientConfig:
       service:
         name: env-injector-webhook-svc

--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -6,6 +6,8 @@ metadata:
     app: env-injector
 webhooks:
   - name: env-injector.hmcts.net
+    admissionReviewVersions: [“v1”, “v1beta1"]
+    sideEffects: NoneOnDryRun
     clientConfig:
       service:
         name: env-injector-webhook-svc

--- a/env-injector-webhook/templates/mutatingwebhook.yaml
+++ b/env-injector-webhook/templates/mutatingwebhook.yaml
@@ -13,6 +13,8 @@ metadata:
     "helm.sh/hook-weight": "-5"
 webhooks:
   - name: env-injector.hmcts.net
+    admissionReviewVersions: [“v1”, “v1beta1"]
+    sideEffects: NoneOnDryRun
     clientConfig:
       service:
         name: {{ include "chart-env-injector.name" . }}-svc


### PR DESCRIPTION
Encountered the following error during helm upgrade step of env-injector release in SBOX:

```
env-injector-webhook   False   Helm upgrade failed: pre-upgrade hooks failed: unable to build kubernetes object for pre-upgrade hook env-injector-webhook/templates/mutatingwebhook.yaml: error validating "": error validating data: [ValidationError(MutatingWebhookConfiguration.webhooks[0]): missing required field "sideEffects" in io.k8s.api.admissionregistration.v1.MutatingWebhook, ValidationError(MutatingWebhookConfiguration.webhooks[0]): missing required field "admissionReviewVersions" in io.k8s.api.admissionregistration.v1.MutatingWebhook]   33d
```

There are two required fields added in this API upgrade so adding them in here based on helm guidance in https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects and https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-request-and-response.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
