### PR TITLE
Fix regex match failure

### DIFF
--- a/deployment/mutatingwebhook-ca-bundle.yaml
+++ b/deployment/mutatingwebhook-ca-bundle.yaml
@@ -6,7 +6,7 @@ metadata:
     app: env-injector
 webhooks:
   - name: env-injector.hmcts.net
-    admissionReviewVersions: ['v1', 'v1beta1']
+    admissionReviewVersions: [v1, v1beta1]
     sideEffects: NoneOnDryRun
     clientConfig:
       service:

--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -6,7 +6,7 @@ metadata:
     app: env-injector
 webhooks:
   - name: env-injector.hmcts.net
-    admissionReviewVersions: ['v1', 'v1beta1']
+    admissionReviewVersions: [v1, v1beta1]
     sideEffects: NoneOnDryRun
     clientConfig:
       service:

--- a/env-injector-webhook/templates/mutatingwebhook.yaml
+++ b/env-injector-webhook/templates/mutatingwebhook.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
 webhooks:
   - name: env-injector.hmcts.net
-    admissionReviewVersions: ['v1', 'v1beta1']
+    admissionReviewVersions: [v1, v1beta1]
     sideEffects: NoneOnDryRun
     clientConfig:
       service:


### PR DESCRIPTION
Helm upgrade failing on different error:

```
helm-controller  reconciliation failed: Helm upgrade failed: pre-upgrade hooks failed: warning: Hook pre-upgrade env-injector-webhook/templates/mutatingwebhook.yaml failed: MutatingWebhookConfiguration.admissionregistration.k8s.io "env-injector-webhook-cfg" is invalid: [webhooks[0].admissionReviewVersions[0]: Invalid value: "“v1”": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?'), webhooks[0].admissionReviewVersions[1]: Invalid value: "“v1beta1\"": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?'), webhooks[0].admissionReviewVersions: Invalid value: []string{"“v1”", "“v1beta1\""}: must include at least one of v1, v1beta1]
```


Seems to not match regex expect and docs show this ` Default to ['v1beta1'].` as how `admissionReviewVersions` expects.
Specifically that it's including the speech marks within the speech marks in the error `"“v1”"`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
