### PR TITLE
DTSPO-8139 Upgrades for K8S V1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx
+      app: sleep
   template:
     metadata:
       labels:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ kube-system       Active   4d3h
 3. Deploy an app in Kubernetes cluster, take `sleep` app as an example
 ```
 $ cat <<EOF | kubectl create -f -
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sleep

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ metadata:
   name: sleep
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/deployment/webhook-create-signed-cert.sh
+++ b/deployment/webhook-create-signed-cert.sh
@@ -83,11 +83,12 @@ kubectl delete csr ${csrName} 2>/dev/null || true
 
 # create  server cert/key CSR and  send to k8s API
 cat <<EOF | kubectl create -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}
 spec:
+  signerName: kubernetes.io/kubelet-serving
   groups:
   - system:authenticated
   request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')

--- a/env-injector-webhook/templates/pre-install-configmap.yaml
+++ b/env-injector-webhook/templates/pre-install-configmap.yaml
@@ -105,11 +105,12 @@ data:
 
     # create  server cert/key CSR and  send to k8s API
     cat <<EOF | kubectl create -f -
-    apiVersion: certificates.k8s.io/v1beta1
+    apiVersion: certificates.k8s.io/v1
     kind: CertificateSigningRequest
     metadata:
       name: ${csrName}
     spec:
+      signerName: kubernetes.io/kubelet-serving
       groups:
       - system:authenticated
       request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')

--- a/env-injector-webhook/test-pod.yaml
+++ b/env-injector-webhook/test-pod.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: rpe
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: sleep
   template:
     metadata:
       labels:

--- a/env-injector-webhook/test-pod.yaml
+++ b/env-injector-webhook/test-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sleep

--- a/webhook.go
+++ b/webhook.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -261,12 +261,12 @@ func createPatch(pod *corev1.Pod, envConfig *Config, annotations map[string]stri
 }
 
 // main mutation process
-func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+func (whsvr *WebhookServer) mutate(ar *v1.AdmissionReview) *v1.AdmissionResponse {
 	req := ar.Request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
 		glog.Errorf("Could not unmarshal raw object: %v", err)
-		return &v1beta1.AdmissionResponse{
+		return &v1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -279,7 +279,7 @@ func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 	// determine whether to perform mutation
 	if !mutationRequired(ignoredNamespaces, &pod.ObjectMeta) {
 		glog.Infof("Skipping mutation for %s/%s due to policy check", pod.Namespace, pod.Name)
-		return &v1beta1.AdmissionResponse{
+		return &v1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -287,7 +287,7 @@ func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 	annotations := map[string]string{admissionWebhookAnnotationStatusKey: "injected"}
 	patchBytes, err := createPatch(&pod, whsvr.envConfig, annotations)
 	if err != nil {
-		return &v1beta1.AdmissionResponse{
+		return &v1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -295,11 +295,11 @@ func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 	}
 
 	glog.Infof("AdmissionResponse: patch=%v\n", string(patchBytes))
-	return &v1beta1.AdmissionResponse{
+	return &v1.AdmissionResponse{
 		Allowed: true,
 		Patch:   patchBytes,
-		PatchType: func() *v1beta1.PatchType {
-			pt := v1beta1.PatchTypeJSONPatch
+		PatchType: func() *v1.PatchType {
+			pt := v1.PatchTypeJSONPatch
 			return &pt
 		}(),
 	}
@@ -327,11 +327,11 @@ func (whsvr *WebhookServer) serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var admissionResponse *v1beta1.AdmissionResponse
-	ar := v1beta1.AdmissionReview{}
+	var admissionResponse *v1.AdmissionResponse
+	ar := v1.AdmissionReview{}
 	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
 		glog.Errorf("Can't decode body: %v", err)
-		admissionResponse = &v1beta1.AdmissionResponse{
+		admissionResponse = &v1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -340,7 +340,7 @@ func (whsvr *WebhookServer) serve(w http.ResponseWriter, r *http.Request) {
 		admissionResponse = whsvr.mutate(&ar)
 	}
 
-	admissionReview := v1beta1.AdmissionReview{}
+	admissionReview := v1.AdmissionReview{}
 	if admissionResponse != nil {
 		admissionReview.Response = admissionResponse
 		if ar.Request != nil {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-8139

Previously just upgraded `admissionregistration.k8s.io/v1beta1` and missed other APIS in deprecation guide [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22).

This includes:
API  | Required Change
------------- | -------------
certificates  | Upgrade to `certificates.k8s.io/v1` and include now required field `signerName` and verify `usages`.
admission  | Upgrade to `k8s.io/api/admission/v1`.
extensions | Upgrade to `apps/v1`.

There's an extensions upgrade too, which we only use in the test-pod here, but I believe we use plum as a test app now which we can use to check deployment of any new env-injector versions. The other API upgrade is included in https://github.com/hmcts/k8s-env-injector/releases/tag/0.1.10. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
