### PR TITLE
Update openssl command

### DIFF
--- a/deployment/webhook-create-signed-cert.sh
+++ b/deployment/webhook-create-signed-cert.sh
@@ -76,7 +76,7 @@ DNS.3 = ${service}.${namespace}.svc
 EOF
 
 openssl genrsa -out ${tmpdir}/server-key.pem 2048
-openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=system:node:${service}.${namespace}.svc;/O=system:nodes" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
 
 # clean-up any previously created CSR for our service. Ignore errors if not present.
 kubectl delete csr ${csrName} 2>/dev/null || true

--- a/env-injector-webhook/templates/pre-install-configmap.yaml
+++ b/env-injector-webhook/templates/pre-install-configmap.yaml
@@ -98,7 +98,7 @@ data:
     EOF
 
     openssl genrsa -out ${tmpdir}/server-key.pem 2048
-    openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+    openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=system:node:${service}.${namespace}.svc;/O=system:nodes" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
 
     # clean-up any previously created CSR for our service. Ignore errors if not present.
     kubectl delete csr ${csrName} 2>/dev/null || true


### PR DESCRIPTION
After most recent update seeing CSR errors in sbox-00 of:
```
  - lastTransitionTime: "2022-06-27T11:01:24Z"
    lastUpdateTime: "2022-06-27T11:01:24Z"
    message: subject organization is not system:nodes
    reason: SignerValidationFailure
    status: "True"
    type: Failed
```

This was introduced from adding the required field `signerName` for the certificates API upgrade, and this signerName requires:
```
Permitted subjects - organizations are exactly ["system:nodes"], common name starts with "system:node:".
```


Similar thread here with an openssl fix that I took this from - https://github.com/kubernetes/kubernetes/issues/99504#issuecomment-909396459


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
